### PR TITLE
Remove deprecated call to `.size()`

### DIFF
--- a/src/inputhistory.js
+++ b/src/inputhistory.js
@@ -18,7 +18,7 @@
 		);
 		
 		var self = this;
-		if (self.size() > 1) {
+		if (self.length > 1) {
 			return self.each(function() {
 				$(this).history(options);
 			});


### PR DESCRIPTION
According to [jQuery's doc](https://api.jquery.com/size/), `.size()` has been deprecated since jQuery 1.8 in favor of [`.length`](https://api.jquery.com/length/), which is a minimum requirement of this plugin:

> The `.size()` method is deprecated as of jQuery 1.8. Use the `.length` property instead.
> The `.size()` method is functionally equivalent to the `.length` property; however, the `.length` property is preferred because it does not have the overhead of a function call.

`.size()` is removed from jQuery 3.

For instance, @xPaw removed this from The Lounge in https://github.com/thelounge/lounge/pull/854.