### PR TITLE
Support multiline inputs

### DIFF
--- a/src/inputhistory.js
+++ b/src/inputhistory.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*!
  * inputhistory
  * https://github.com/erming/inputhistory
@@ -7,36 +9,40 @@
 	$.inputhistory = {};
 	$.inputhistory.defaultOptions = {
 		history: [],
-		preventSubmit: false
+		preventSubmit: false,
 	};
-	
+
 	$.fn.history = // Alias
 	$.fn.inputhistory = function(options) {
 		options = $.extend(
 			$.inputhistory.defaultOptions,
 			options
 		);
-		
+
 		var self = this;
 		if (self.length > 1) {
 			return self.each(function() {
 				$(this).history(options);
 			});
 		}
-		
+
 		var history = options.history;
 		history.push("");
-		
+
 		var i = 0;
 		self.on("keydown", function(e) {
 			var key = e.which;
 			switch (key) {
 			case 13: // Enter
-				if (self.val() != "") {
+				if (e.shiftKey) {
+					return; // Multiline input
+				}
+
+				if (self.val() !== "") {
 					i = history.length;
 					history[i - 1] = self.val();
 					history.push("");
-					if (history[i - 1] == history[i - 2]) {
+					if (history[i - 1] === history[i - 2]) {
 						history.splice(-2, 1);
 						i--;
 					}
@@ -46,25 +52,35 @@
 				}
 				self.val("");
 				break;
-			
+
 			case 38: // Up
 			case 40: // Down
+				if (e.ctrlKey || e.metaKey) {
+					break;
+				}
+
+				if (this.value.indexOf("\n") >= 0 &&
+						(key === 38 && this.selectionStart > 0) ||
+						(key === 40 && this.selectionStart < this.value.length)) {
+					return; // Don't prevent default when multiline and going up/down
+				}
+
 				history[i] = self.val();
-				if (key == 38 && i != 0) {
+				if (key === 38 && i !== 0) {
 					i--;
-				} else if (key == 40 && i < history.length - 1) {
+				} else if (key === 40 && i < history.length - 1) {
 					i++;
 				}
 				self.val(history[i]);
 				break;
-			
+
 			default:
 				return;
 			}
-			
+
 			e.preventDefault();
 		});
-		
+
 		return this;
-	}
+	};
 })(jQuery);


### PR DESCRIPTION
On multiline inputs (`textarea` elements), hitting <kbd>Up</kbd>/<kbd>Down</kbd>, when there are multiple lines, needs to take over going back in history. Also <kbd>Shift</kbd>+<kbd>Enter</kbd> lets you add a new line.

Other changes include my editor cleaning up trailing whitespaces (review with `?w=1` in URL to ignore those), and adding strict mode 'coz it's good :)

This is actually a port of changes we've been using for 1.5y now (see https://github.com/thelounge/lounge/blob/master/client/js/libs/jquery/inputhistory.js#L58-L71) and it has served us well so far. I'm trying to sync our changes with the upstream project so we can correctly refer to this package instead of keeping a copy of our own :)